### PR TITLE
Serializer updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,23 @@ jobs:
     working_directory: ~/django-enum-choices
     docker:
       - image: circleci/python:3.6.4
+        environment:
+          DATABASE_URL: postgresql://root@localhost/test_django_enum_choices?sslmode=disable
+      - image: circleci/postgres:11.4
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: test_django_enum_choices
+
     steps:
       - checkout
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
 

--- a/django_enum_choices/requirements.txt
+++ b/django_enum_choices/requirements.txt
@@ -5,3 +5,4 @@ flake8==3.7.7
 pytest==4.6.3
 pytest-django==3.5.0
 pytest-pythonpath==0.7.3
+django-environ==0.4.5

--- a/django_enum_choices/requirements.txt
+++ b/django_enum_choices/requirements.txt
@@ -1,5 +1,6 @@
 Django==2.2.2
 djangorestframework==3.9.4
+psycopg2==2.8.3
 flake8==3.7.7
 pytest==4.6.3
 pytest-django==3.5.0

--- a/django_enum_choices/serializers.py
+++ b/django_enum_choices/serializers.py
@@ -23,8 +23,6 @@ class EnumChoiceField(serializers.Field):
         return value.value
 
     def to_internal_value(self, value):
-        # TODO: Handle extra arguments: `allow_null`, `required`, etc
-
         try:
             return self.enum_class(value)
         except ValueError:

--- a/django_enum_choices/tests/settings.py
+++ b/django_enum_choices/tests/settings.py
@@ -1,6 +1,17 @@
 from __future__ import unicode_literals
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:"
+    },
+    'postgresql': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'django_enum_choices'
+    }
+}
+
+DATABASE_ROUTERS = ['tests.testapp.database_routers.DataBaseRouter']
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/django_enum_choices/tests/settings.py
+++ b/django_enum_choices/tests/settings.py
@@ -1,14 +1,16 @@
 from __future__ import unicode_literals
 
+import environ
+
+env = environ.Env()
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:"
     },
-    'postgresql': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'django_enum_choices'
-    }
+    'postgresql': env.db('DATABASE_URL', default='postgres:///django_enum_choices')
+
 }
 
 DATABASE_ROUTERS = ['tests.testapp.database_routers.DataBaseRouter']

--- a/django_enum_choices/tests/test_serializer_fields.py
+++ b/django_enum_choices/tests/test_serializer_fields.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from rest_framework.exceptions import ValidationError
 
-from django_enum_choices.serializers import EnumChoiceField
+from django_enum_choices.serializers import EnumChoiceField, MultipleEnumChoiceField
 from .testapp.enumerations import IntTestEnum, CharTestEnum
 
 
@@ -44,3 +44,51 @@ class TestSerializerField(TestCase):
         result = field.to_internal_value('first')
 
         self.assertEqual(result, CharTestEnum.FIRST)
+
+
+class TestMultipleSerializerField(TestCase):
+    def test_to_representation_returns_list_of_ints(self):
+        field = MultipleEnumChoiceField(enum_class=IntTestEnum)
+
+        result = field.to_representation([IntTestEnum.FIRST, IntTestEnum.SECOND])
+
+        self.assertEqual([1, 2], result)
+
+    def test_to_representation_returns_list_of_strings(self):
+        field = MultipleEnumChoiceField(enum_class=CharTestEnum)
+
+        result = field.to_representation([CharTestEnum.FIRST, CharTestEnum.SECOND])
+
+        self.assertEqual(['first', 'second'], result)
+
+    def test_to_internal_value_fails_when_value_is_not_list(self):
+        field = MultipleEnumChoiceField(enum_class=IntTestEnum)
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            'Expected a list of items but got type "int".'
+        ):
+            field.to_internal_value(5)
+
+    def test_to_internal_value_fails_when_not_allowed_empty_field_gets_empty_list(self):
+        field = MultipleEnumChoiceField(enum_class=IntTestEnum)
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            'This selection may not be empty.'
+        ):
+            field.to_internal_value([])
+
+    def test_to_internal_value_returns_list_of_enums_when_value_is_list_of_ints(self):
+        field = MultipleEnumChoiceField(enum_class=IntTestEnum)
+
+        result = field.to_internal_value([1, 2])
+
+        self.assertEqual([IntTestEnum.FIRST, IntTestEnum.SECOND], result)
+
+    def test_to_internal_value_returns_list_of_enums_when_value_is_list_of_strings(self):
+        field = MultipleEnumChoiceField(enum_class=CharTestEnum)
+
+        result = field.to_internal_value(['first', 'second'])
+
+        self.assertEqual([CharTestEnum.FIRST, CharTestEnum.SECOND], result)

--- a/django_enum_choices/tests/test_serializer_integrations.py
+++ b/django_enum_choices/tests/test_serializer_integrations.py
@@ -196,3 +196,14 @@ class ModelSerializerIntegrationTests(TestCase):
         serializer = Serializer(data={'enumeration': None})
 
         self.assertTrue(serializer.is_valid())
+
+    def test_initialization_with_many_initializes_list_field(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(enum_class=CharTestEnum, many=True)
+
+        serializer = Serializer(data={})
+
+        self.assertIsInstance(
+            serializer.get_fields()['enumeration'],
+            serializers.ListField
+        )

--- a/django_enum_choices/tests/test_serializer_integrations.py
+++ b/django_enum_choices/tests/test_serializer_integrations.py
@@ -2,12 +2,16 @@ from django.test import TestCase
 
 from rest_framework import serializers
 
-from django_enum_choices.serializers import EnumChoiceField, EnumChoiceModelSerializerMixin
+from django_enum_choices.serializers import (
+    EnumChoiceField,
+    EnumChoiceModelSerializerMixin,
+    MultipleEnumChoiceField
+)
 from .testapp.models import StringEnumeratedModel
 from .testapp.enumerations import CharTestEnum
 
 
-class SerializerIntegrationTests(TestCase):
+class EnumChoiceFieldSerializerIntegrationTests(TestCase):
     class Serializer(serializers.Serializer):
         enumeration = EnumChoiceField(enum_class=CharTestEnum)
 
@@ -25,6 +29,209 @@ class SerializerIntegrationTests(TestCase):
         result = serializer.validated_data['enumeration']
 
         self.assertEqual(result, CharTestEnum.FIRST)
+
+    def test_serializer_is_not_valid_when_field_is_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': 'first'})
+
+        self.assertTrue(serializer.is_valid)
+
+    def test_serializer_does_not_add_field_to_validated_data_when_not_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertNotIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_adds_field_to_validated_data_when_not_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={'enumeration': 'first'})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_is_not_valid_when_field_is_not_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                allow_null=True
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertTrue(serializer.is_valid())
+
+
+class MultipleEnumChoiceFieldSerializerIntegrationTests(TestCase):
+    class Serializer(serializers.Serializer):
+        enumeration = MultipleEnumChoiceField(enum_class=CharTestEnum)
+
+    def test_multiple_field_is_serialized_correctly(self):
+        serializer = self.Serializer({
+            'enumeration': [CharTestEnum.FIRST, CharTestEnum.SECOND]
+        })
+
+        result = serializer.data['enumeration']
+
+        self.assertEqual(result, ['first', 'second'])
+
+    def test_multiple_field_is_deserialized_correctly(self):
+        serializer = self.Serializer(
+            data={
+                'enumeration': [CharTestEnum.FIRST, CharTestEnum.SECOND]
+            }
+        )
+        serializer.is_valid()
+
+        result = serializer.validated_data['enumeration']
+
+        self.assertEqual(result, [CharTestEnum.FIRST, CharTestEnum.SECOND])
+
+    def test_serializer_is_not_valid_when_field_is_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_not_valid_when_field_is_required_and_provided_but_not_a_list(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': 'first'})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': ['first']})
+
+        self.assertTrue(serializer.is_valid)
+
+    def test_serializer_does_not_add_field_to_validated_data_when_not_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertNotIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_adds_field_to_validated_data_when_not_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={'enumeration': ['first']})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_is_not_valid_when_field_is_not_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum,
+                allow_null=True
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_serializer_is_not_valid_when_field_is_not_allow_empty_but_empty_list_is_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': []})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_allow_empty_and_empty_list_is_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = MultipleEnumChoiceField(
+                enum_class=CharTestEnum,
+                allow_empty=True
+            )
+
+        serializer = Serializer(data={'enumeration': []})
+
+        self.assertTrue(serializer.is_valid())
 
 
 class ModelSerializerIntegrationTests(TestCase):
@@ -122,88 +329,4 @@ class ModelSerializerIntegrationTests(TestCase):
         self.assertEqual(
             CharTestEnum.SECOND,
             instance.enumeration
-        )
-
-    def test_serializer_is_not_valid_when_field_is_required_and_not_provided(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum
-            )
-
-        serializer = Serializer(data={})
-
-        self.assertFalse(serializer.is_valid())
-
-    def test_serializer_is_valid_when_field_is_required_and_provided(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum
-            )
-
-        serializer = Serializer(data={'enumeration': 'first'})
-
-        self.assertTrue(serializer.is_valid)
-
-    def test_serializer_does_not_add_field_to_validated_data_when_not_required_and_not_provided(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum,
-                required=False
-            )
-
-        serializer = Serializer(data={})
-        is_valid = serializer.is_valid()
-
-        self.assertTrue(is_valid)
-        self.assertNotIn(
-            'enumeration',
-            serializer.validated_data.keys()
-        )
-
-    def test_serializer_adds_field_to_validated_data_when_not_required_and_provided(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum,
-                required=False
-            )
-
-        serializer = Serializer(data={'enumeration': 'first'})
-        is_valid = serializer.is_valid()
-
-        self.assertTrue(is_valid)
-        self.assertIn(
-            'enumeration',
-            serializer.validated_data.keys()
-        )
-
-    def test_serializer_is_not_valid_when_field_is_not_nullable_and_value_is_none(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum
-            )
-
-        serializer = Serializer(data={'enumeration': None})
-
-        self.assertFalse(serializer.is_valid())
-
-    def test_serializer_is_valid_when_field_is_nullable_and_value_is_none(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(
-                enum_class=CharTestEnum,
-                allow_null=True
-            )
-
-        serializer = Serializer(data={'enumeration': None})
-
-        self.assertTrue(serializer.is_valid())
-
-    def test_initialization_with_many_initializes_list_field(self):
-        class Serializer(serializers.Serializer):
-            enumeration = EnumChoiceField(enum_class=CharTestEnum, many=True)
-
-        serializer = Serializer(data={})
-
-        self.assertIsInstance(
-            serializer.get_fields()['enumeration'],
-            serializers.ListField
         )

--- a/django_enum_choices/tests/test_serializer_integrations.py
+++ b/django_enum_choices/tests/test_serializer_integrations.py
@@ -123,3 +123,76 @@ class ModelSerializerIntegrationTests(TestCase):
             CharTestEnum.SECOND,
             instance.enumeration
         )
+
+    def test_serializer_is_not_valid_when_field_is_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': 'first'})
+
+        self.assertTrue(serializer.is_valid)
+
+    def test_serializer_does_not_add_field_to_validated_data_when_not_required_and_not_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertNotIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_adds_field_to_validated_data_when_not_required_and_provided(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                required=False
+            )
+
+        serializer = Serializer(data={'enumeration': 'first'})
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+        self.assertIn(
+            'enumeration',
+            serializer.validated_data.keys()
+        )
+
+    def test_serializer_is_not_valid_when_field_is_not_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_serializer_is_valid_when_field_is_nullable_and_value_is_none(self):
+        class Serializer(serializers.Serializer):
+            enumeration = EnumChoiceField(
+                enum_class=CharTestEnum,
+                allow_null=True
+            )
+
+        serializer = Serializer(data={'enumeration': None})
+
+        self.assertTrue(serializer.is_valid())

--- a/django_enum_choices/tests/testapp/database_routers.py
+++ b/django_enum_choices/tests/testapp/database_routers.py
@@ -1,0 +1,54 @@
+from django.apps import apps
+from django.db import models
+from django.contrib.postgres import fields as pg_fields
+
+
+POSTGRES = 'postgresql'
+DEFAULT = 'default'
+
+
+class DataBaseRouter:
+    def _get_postgresql_fields(self):
+        return [
+            var for var in vars(pg_fields).values()
+            if isinstance(var, type) and issubclass(var, models.Field)
+        ]
+
+    def _get_field_classes(self, db_obj):
+        return [
+            type(field) for field in db_obj._meta.get_fields()
+        ]
+
+    def has_postgres_field(self, db_obj):
+        field_classes = self._get_field_classes(db_obj)
+
+        return len([
+            field_cls for field_cls in field_classes
+            if field_cls in self._get_postgresql_fields()
+        ]) > 0
+
+    def db_for_read(self, model, **hints):
+        if self.has_postgres_field(model):
+            return POSTGRES
+
+        return DEFAULT
+
+    def db_for_write(self, model, **hints):
+        if self.has_postgres_field(model):
+            return POSTGRES
+
+        return DEFAULT
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if not self.has_postgres_field(obj1) and not self.has_postgres_field(obj2):
+            return True
+
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if model_name is not None and \
+           db == DEFAULT and \
+           self.has_postgres_field(apps.get_model(app_label, model_name)):
+            return False
+
+        return True

--- a/django_enum_choices/tests/testapp/models.py
+++ b/django_enum_choices/tests/testapp/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.postgres.fields import ArrayField
 
 from django_enum_choices.fields import EnumChoiceField
 
@@ -32,4 +33,13 @@ class EnumChoiceFieldWithDefaultModel(models.Model):
     enumeration = EnumChoiceField(
         CharTestEnum,
         default=CharTestEnum.FIRST
+    )
+
+
+class MultipleEnumeratedModel(models.Model):
+    enumeration = ArrayField(
+        base_field=EnumChoiceField(
+            enum_class=CharTestEnum
+        ),
+        null=True
     )


### PR DESCRIPTION
Related Issue: https://github.com/HackSoftware/django-enum-choices/issues/4

To think about: It might be cleaner to create a `MultipleEnumChoiceField` that subclasses `EnumChoiceField` and just handles representation and internal value manipulation instead of swapping the object instance in `__new__`.
