### PR TITLE
Bugfix migration generation

### DIFF
--- a/django_enum_choices/fields.py
+++ b/django_enum_choices/fields.py
@@ -38,7 +38,7 @@ class EnumChoiceField(CharField):
             built_choices
         )  # Saved for deconstruction
 
-        kwargs['choices'] = self.build_choices()
+        kwargs['choices'] = built_choices
 
         calculated_max_length = self._calculate_max_length(**kwargs)
 


### PR DESCRIPTION
Fixes the equal serialization on different field initialization version with the same `enum_class`, returned from `deconstruct`.

Relevant issue: https://github.com/HackSoftware/django-enum-choices/issues/28