### PR TITLE
Add support for 'in' lookups with django-filter

### DIFF
--- a/django_enum_choices/filters.py
+++ b/django_enum_choices/filters.py
@@ -16,6 +16,9 @@ class EnumChoiceFilter(filters.ChoiceFilter):
             **kwargs
         )
 
+class EnumChoiceInFilter(filters.BaseInFilter, EnumChoiceFilter):
+    pass
+
 
 class EnumChoiceFilterSetMixin:
     """
@@ -28,6 +31,12 @@ class EnumChoiceFilterSetMixin:
     @classmethod
     def filter_for_lookup(cls, field, lookup_type):
         if isinstance(field, EnumChoiceField):
+            if lookup_type == "in":
+                return EnumChoiceInFilter, {
+                    'enum_class': field.enum_class,
+                    'choice_builder': field.choice_builder
+                }
+
             return EnumChoiceFilter, {
                 'enum_class': field.enum_class,
                 'choice_builder': field.choice_builder


### PR DESCRIPTION
It looks like `in`-type lookups with django-filter are not supported right now (please correct me if I'm wrong).

I've put together the necessary changes here, based on [how django-filters does it](https://github.com/carltongibson/django-filter/blob/da4b64ea8dde19304b552592a32b343e9aefe9da/django_filters/filterset.py#L407), and as you can see they're fairly simple changes.

I have not added tests, but can do so if that's needed.

I also would recommend considering restricting -- or at least mentioned in the docs -- what lookup types are actually supported. Otherwise, the server seems to throw 500 errors for unsupported types.