### PR TITLE
Bugfix: Calculating max length properly when attribute_value choice builder is provided

### DIFF
--- a/django_enum_choices/fields.py
+++ b/django_enum_choices/fields.py
@@ -52,8 +52,14 @@ class EnumChoiceField(CharField):
             validator for validator in self.validators
             if not isinstance(validator, MaxLengthValidator)
         ]
+
+        should_validate_attribute_name = self.should_validate_attribute_name(**kwargs)
+
         self.validators.append(
-            EnumValueMaxLengthValidator(kwargs['max_length'])
+            EnumValueMaxLengthValidator(
+                limit_value=kwargs['max_length'],
+                validate_attribute_name=should_validate_attribute_name
+            )
         )
 
     def _get_choice_builder(self, choice_builder):
@@ -141,6 +147,13 @@ class EnumChoiceField(CharField):
                 code='invalid_choice',
                 params={'value': value}
             )
+
+    def should_validate_attribute_name(self, **kwargs) -> bool:
+        choices = kwargs['choices']
+        # Checking whether the provided choice builder returns tuples containing attribute as a first element
+        has_attribute_choice_builder = hasattr(self.enum_class, choices[0][0])
+
+        return has_attribute_choice_builder
 
     def value_to_string(self, obj):
         value = self.value_from_object(obj)

--- a/django_enum_choices/fields.py
+++ b/django_enum_choices/fields.py
@@ -53,12 +53,10 @@ class EnumChoiceField(CharField):
             if not isinstance(validator, MaxLengthValidator)
         ]
 
-        should_validate_attribute_name = self.should_validate_attribute_name(**kwargs)
-
         self.validators.append(
             EnumValueMaxLengthValidator(
-                limit_value=kwargs['max_length'],
-                validate_attribute_name=should_validate_attribute_name
+                value_builder=self.get_prep_value,
+                limit_value=kwargs['max_length']
             )
         )
 
@@ -147,13 +145,6 @@ class EnumChoiceField(CharField):
                 code='invalid_choice',
                 params={'value': value}
             )
-
-    def should_validate_attribute_name(self, **kwargs) -> bool:
-        choices = kwargs['choices']
-        # Checking whether the provided choice builder returns tuples containing attribute as a first element
-        has_attribute_choice_builder = hasattr(self.enum_class, choices[0][0])
-
-        return has_attribute_choice_builder
 
     def value_to_string(self, obj):
         value = self.value_from_object(obj)

--- a/django_enum_choices/tests/test_model_integrations.py
+++ b/django_enum_choices/tests/test_model_integrations.py
@@ -4,13 +4,14 @@ from django.core.exceptions import ValidationError
 
 from django_enum_choices.fields import EnumChoiceField
 
-from .testapp.enumerations import CharTestEnum, IntTestEnum
+from .testapp.enumerations import CharTestEnum, CharLongValuesTestEnum, IntTestEnum
 from .testapp.models import (
     IntegerEnumeratedModel,
     StringEnumeratedModel,
     NullableEnumeratedModel,
     BlankNullableEnumeratedModel,
-    EnumChoiceFieldWithDefaultModel
+    EnumChoiceFieldWithDefaultModel,
+    AttributeChoiceBuilderEnumeratedModel
 )
 
 
@@ -160,6 +161,13 @@ class ModelIntegrationTests(TestCase):
 
     def test_enum_value_from_enum_class_does_not_raise_error_on_clean(self):
         instance = StringEnumeratedModel(enumeration=CharTestEnum.FIRST)
+        instance.full_clean()
+        instance.save()
+
+        self.assertIsNotNone(instance)
+
+    def test_attribute_choice_builder_validates_enum_field_name_length(self):
+        instance = AttributeChoiceBuilderEnumeratedModel(enumeration=CharLongValuesTestEnum.FIRST)
         instance.full_clean()
         instance.save()
 

--- a/django_enum_choices/tests/testapp/enumerations.py
+++ b/django_enum_choices/tests/testapp/enumerations.py
@@ -7,6 +7,12 @@ class CharTestEnum(Enum):
     THIRD = 'third'
 
 
+class CharLongValuesTestEnum(Enum):
+    FIRST = 'first value'
+    SECOND = 'second value'
+    THIRD = 'third value'
+
+
 class IntTestEnum(Enum):
     FIRST = 1
     SECOND = 2

--- a/django_enum_choices/tests/testapp/models.py
+++ b/django_enum_choices/tests/testapp/models.py
@@ -2,8 +2,9 @@ from django.db import models
 from django.contrib.postgres.fields import ArrayField
 
 from django_enum_choices.fields import EnumChoiceField
+from django_enum_choices.choice_builders import attribute_value
 
-from .enumerations import CharTestEnum, IntTestEnum
+from .enumerations import CharTestEnum, CharLongValuesTestEnum, IntTestEnum
 
 
 def custom_choice_builder(choice):
@@ -53,4 +54,11 @@ class CustomChoiceBuilderEnumeratedModel(models.Model):
     enumeration = EnumChoiceField(
         enum_class=CharTestEnum,
         choice_builder=custom_choice_builder
+    )
+
+
+class AttributeChoiceBuilderEnumeratedModel(models.Model):
+    enumeration = EnumChoiceField(
+        enum_class=CharLongValuesTestEnum,
+        choice_builder=attribute_value
     )

--- a/django_enum_choices/validators.py
+++ b/django_enum_choices/validators.py
@@ -7,6 +7,11 @@ class EnumValueMaxLengthValidator(MaxLengthValidator):
     attempts to return `len(value)` when value is an enumeration
     instance, which raises an error
     """
+    def __init__(self, validate_attribute_name: bool = False, *args, **kwargs):
+        self.validate_attribute_name = validate_attribute_name
+
+        super().__init__(*args, **kwargs)
 
     def clean(self, x):
-        return len(str(x.value))
+        value_to_validate = x.name if self.validate_attribute_name else x.value
+        return len(str(value_to_validate))

--- a/django_enum_choices/validators.py
+++ b/django_enum_choices/validators.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from django.core.validators import MaxLengthValidator
 
 
@@ -7,11 +9,12 @@ class EnumValueMaxLengthValidator(MaxLengthValidator):
     attempts to return `len(value)` when value is an enumeration
     instance, which raises an error
     """
-    def __init__(self, validate_attribute_name: bool = False, *args, **kwargs):
-        self.validate_attribute_name = validate_attribute_name
+    def __init__(self, value_builder: Callable,  *args, **kwargs):
+        self.value_builder = value_builder
 
         super().__init__(*args, **kwargs)
 
     def clean(self, x):
-        value_to_validate = x.name if self.validate_attribute_name else x.value
-        return len(str(value_to_validate))
+        value = self.value_builder(x)
+
+        return len(value)


### PR DESCRIPTION
Related to #42 

---

When `attribute_value` choice builder was provided, the `EnumChoiceField._calculate_max_length` method used to iterate `kwargs['choices']` like:

```python
for choice, _ in kwargs['choices']
```

which works when having any other choice builder, different than `attribute_value`:

- Let's say we have this enum:

```python
class TestEnum(Enum):
    FOO = 'foo'
    BAR = 'A' * 100
```

Then for each choice builder we have:

- `value_value` -> `[('foo', 'foo'), ('AAA...', 'AAA...')]`
- `value_attribute` -> `[('foo', 'FOO'), ('AAA...', 'BAR')]`
- `attribute_attribute` -> `[('FOO', 'FOO'), ('BAR', 'BAR')]`

Which will result in properly validated maximum length. But when having `attribute_value` we have the following:

```python
[('FOO', 'foo'), ('BAR', 'AAA...')]
#  ^               ^
```

thus the max length will be `3 == len('FOO')` (the first element is the field name, which is inaccurate in this case).

This happens with every choice builder that has the `attribute` as a first element in the tuple pairs (including `attribute_attribute`, but it doesn't matter there since it has the same values).