### PR TITLE
[#45] DRF: Model with blank=True leads to error in serializer.EnumChoiceField

### DIFF
--- a/django_enum_choices/serializers.py
+++ b/django_enum_choices/serializers.py
@@ -98,7 +98,7 @@ class EnumChoiceModelSerializerMixin:
             # `model_field` is used only in children of DRF's `ModelField`
             # `choices` is not used because we use `field.enum_class` to validate the choice
             # `max_length` is generated from the model field's max_length and we don't use it
-            dump_kwargs = ('model_field', 'choices', 'max_length')
+            dump_kwargs = ('model_field', 'choices', 'max_length', 'allow_blank')
 
             initial_kwargs = {
                 'enum_class': model_field.enum_class,

--- a/django_enum_choices/tests/test_serializer_integrations.py
+++ b/django_enum_choices/tests/test_serializer_integrations.py
@@ -10,7 +10,8 @@ from django_enum_choices.serializers import (
 from .testapp.models import (
     StringEnumeratedModel,
     MultipleEnumeratedModel,
-    CustomChoiceBuilderEnumeratedModel
+    CustomChoiceBuilderEnumeratedModel,
+    BlankNullableEnumeratedModel
 )
 from .testapp.enumerations import CharTestEnum
 
@@ -356,6 +357,19 @@ class EnumChoiceFieldModelSerializerIntegrationTests(TestCase):
             CharTestEnum.FIRST,
             instance.enumeration
         )
+
+    def test_field_can_handle_allow_blank(self):
+        # See GH-45
+        class Serializer(EnumChoiceModelSerializerMixin, serializers.ModelSerializer):
+            class Meta:
+                model = BlankNullableEnumeratedModel
+                fields = ('enumeration', )
+
+        instance = StringEnumeratedModel.objects.create(
+            enumeration=CharTestEnum.FIRST
+        )
+        serializer = Serializer(instance)
+        serializer.data
 
 
 class MultipleEnumChoiceFieldModelSerializerIntegrationTests(TestCase):


### PR DESCRIPTION
closes #45