### PR TITLE
Fix setting widget in formfield

### DIFF
--- a/django_enum_choices/fields.py
+++ b/django_enum_choices/fields.py
@@ -201,7 +201,7 @@ class EnumChoiceField(CharField):
         for k in list(kwargs):
             if k not in (
                 'coerce', 'choices', 'required', 'enum_class', 'disabled',
-                'choice_builder, ''widget', 'label', 'initial', 'help_text',
+                'choice_builder', 'widget', 'label', 'initial', 'help_text',
                 'error_messages', 'show_hidden_initial',
             ):
                 del kwargs[k]


### PR DESCRIPTION
A typo in EnumChoiceField.formfield() doesn't allow setting widget (or choice_builder).