### PR TITLE
Fix to accept non-Enum values in Python 3.8 or later

### DIFF
--- a/django_enum_choices/forms.py
+++ b/django_enum_choices/forms.py
@@ -42,4 +42,4 @@ class EnumChoiceField(forms.ChoiceField):
         return value
 
     def valid_value(self, value):
-        return value in self.enum_class
+        return isinstance(value, self.enum_class) and value in self.enum_class


### PR DESCRIPTION
`Enum.__contains__()` in Python 3.8 start rejecting non-Enum values.

```python
Python 3.8.1 (default, Feb 10 2020, 20:20:52) 
[GCC 7.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from enum import Enum
>>> class E(Enum):
...   A = 0
... 
>>> 0 in E
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/.pyenv/versions/3.8.1/lib/python3.8/enum.py", line 310, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'int' and 'EnumMeta'
```

So `forms.EnumChoiceField` fails to handle a value not defined in `enum_class`. This patch fixes to check `value` is `Enum` or not.

```python
  File "/home/user/django-project/view.py", line 167, in get
    if not form.is_valid():
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/forms.py", line 177, in is_valid
    return self.is_bound and not self.errors
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/forms.py", line 172, in errors
    self.full_clean()
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/forms.py", line 374, in full_clean
    self._clean_fields()
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/forms.py", line 392, in _clean_fields
    value = field.clean(value)
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/fields.py", line 150, in clean
    self.validate(value)
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django/forms/fields.py", line 812, in validate
    if value and not self.valid_value(value):
  File "/home/user/django-project/venv/lib/python3.8/site-packages/django_enum_choices/forms.py", line 45, in valid_value
    return value in self.enum_class
  File "/home/user/.pyenv/versions/3.8.1/lib/python3.8/enum.py", line 310, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumMeta'
```
